### PR TITLE
Minor modifs in environment and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ ms.pdf
 dag.pdf
 
 .idea
+
+# Mac OSX
+.DS_Store

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,9 @@ channels:
   - defaults
   - conda-forge
 
+variables:
+  PYTHONNOUSERSITE: "1"
+
 dependencies:
   - gammapy=0.19
   - iminuit=2.8.4


### PR DESCRIPTION
Adding `PYTHONNOUSERSITE=1` prevents the user site packages to take precedence over the packages in the environment.