### PR TITLE
started to fix the multi-instrument analysis

### DIFF
--- a/src/data/multi-instrument/make.py
+++ b/src/data/multi-instrument/make.py
@@ -35,7 +35,7 @@ def reduce_magic_data():
     e_max = 20 * u.TeV
 
     data_store = DataStore.from_dir("input/magic")
-    observations = data_store.get_observations(required_irf=["rad_max", "aeff", "edisp"])
+    observations = data_store.get_observations(required_irf=["aeff", "edisp", "rad_max"])
 
     # adopt the same energy axes used for flute and DL3 production
     energy_axis = MapAxis.from_energy_bounds(

--- a/src/data/multi-instrument/make.py
+++ b/src/data/multi-instrument/make.py
@@ -41,9 +41,7 @@ def reduce_magic_data():
     e_max = 20 * u.TeV
 
     data_store = DataStore.from_dir("input/magic")
-    observations = data_store.get_observations(
-        required_irf=["aeff", "edisp", "rad_max"]
-    )
+    observations = data_store.get_observations(required_irf=["aeff", "edisp", "rad_max"])
 
     # adopt the same energy axes used for flute and DL3 production
     energy_axis = MapAxis.from_energy_bounds(

--- a/src/figures/multi_instrument_analysis.py
+++ b/src/figures/multi_instrument_analysis.py
@@ -5,26 +5,34 @@ from gammapy.modeling.models import Models
 import matplotlib.pyplot as plt
 
 sed_x_label = r"$E\,/\,{\rm TeV}$"
-sed_y_label = r"$E^2\,{\rm d}\phi/{\rm d}\phi\,/\,({\rm erg}\,{\rm cm}^{-2}\,{\rm s}^{-1})$"
+sed_y_label = (
+    r"$E^2\,{\rm d}\phi/{\rm d}\phi\,/\,({\rm erg}\,{\rm cm}^{-2}\,{\rm s}^{-1})$"
+)
 
 figsize = config.FigureSizeAA(aspect_ratio=1.618, width_aa="intermediate")
 fig = plt.figure(figsize=figsize.inch)
 ax = fig.add_axes([0.1, 0.1, 0.9, 0.9])
 
 # load the flux points and plot them
-fermi_flux_points = FluxPoints.read("../data/multi-instrument/datasets/flux_points/crab_fermi_flux_points.fits")
-magic_flux_points = FluxPoints.read("../data/multi-instrument/datasets/flux_points/crab_magic_flux_points.fits")
-hawc_flux_points = FluxPoints.read("../data/multi-instrument/input/hawc/HAWC19_flux_points.fits")
+fermi_flux_points = FluxPoints.read(
+    "../data/multi-instrument/datasets/flux_points/crab_fermi_flux_points.fits"
+)
+magic_flux_points = FluxPoints.read(
+    "../data/multi-instrument/datasets/flux_points/crab_magic_flux_points.fits"
+)
+hawc_flux_points = FluxPoints.read(
+    "../data/multi-instrument/input/hawc/HAWC19_flux_points.fits"
+)
 
 # load the best-fit model
 models = Models.read("../data/multi-instrument/results/crab_multi_instrument_fit.yaml")
 crab_lp = models["Crab Nebula"].spectral_model
 
 plot_kwargs = {
-   "energy_bounds": [0.01, 300] * u.TeV,
-   "sed_type": "e2dnde",
-   "yunits": u.Unit("erg cm-2 s-1"),
-   "xunits": u.TeV,
+    "energy_bounds": [0.01, 300] * u.TeV,
+    "sed_type": "e2dnde",
+    "yunits": u.Unit("erg cm-2 s-1"),
+    "xunits": u.TeV,
 }
 
 crab_lp.plot(ax=ax, ls="-", lw=1.5, color="crimson", label="joint fit", **plot_kwargs)
@@ -32,8 +40,6 @@ crab_lp.plot_error(ax=ax, facecolor="crimson", alpha=0.4, **plot_kwargs)
 
 fermi_flux_points.plot(ax=ax, sed_type="e2dnde", color="k", label="Fermi-LAT")
 magic_flux_points.plot(ax=ax, sed_type="e2dnde", color="dodgerblue", label="MAGIC")
-table = magic_flux_points.to_table(sed_type="e2dnde")
-print(table)
 hawc_flux_points.plot(ax=ax, sed_type="e2dnde", color="goldenrod", label="HAWC")
 
 ax.set_xlim(plot_kwargs["energy_bounds"])
@@ -41,3 +47,4 @@ ax.set_xlabel(sed_x_label)
 ax.set_ylabel(sed_y_label)
 ax.legend()
 fig.savefig("multi_instrument_analysis.pdf")
+fig.savefig("multi_instrument_analysis.png")


### PR DESCRIPTION
This PR starts to fix the multi-instrument example.

I have isolated the problem. The fit with the MAGIC data fails when a `Models` object composed of a `SkyModel` and a `FovbackgroundModel` (what is read from the `Fermi-LAT-3FHL_models.yaml`) is passed to the fit.
If I pass a simple `SkyModel` with the log parabola, the fit works just fine.

Is there a way to exclude it? 
Will keep working on this.