### PR TITLE
Reformat author list

### DIFF
--- a/src/ms-review.tex
+++ b/src/ms-review.tex
@@ -84,51 +84,51 @@
 
 \author{
         Axel Donath \thanks{Mail inquiries to:
-        \href{mailto:GAMMAPY-COORDINATION-L@IN2P3.FR}{GAMMAPY-COORDINATION-L@IN2P3.FR}} \inst{\ref{inst:28}} \and
-        Régis Terrier \inst{\ref{inst:20}} \and
-        Quentin Remy \inst{\ref{inst:17}} \and
-        Atreyee Sinha \inst{\ref{inst:15}} \and
-        Cosimo Nigro \inst{\ref{inst:24}} \and
-        Fabio Pintore \inst{\ref{inst:26}} \and
-        Bruno Khélifi \inst{\ref{inst:20}} \and
-        Laura Olivera-Nieto \inst{\ref{inst:17}}\and
-        Jose Enrique {Ruiz} \inst{\ref{inst:23}} \and
-        Kai Brügge \inst{\ref{inst:10},\ref{inst:11}} \and
-        Maximilian Linhoff \inst{\ref{inst:11}} \and
-        Jose Louis {Contreras} \inst{\ref{inst:15}} \and
-        Fabio Acero \inst{\ref{inst:1}} \and
-        Arnau Aguasca-Cabot \inst{\ref{inst:2}, \ref{inst:3}, \ref{inst:4}, \ref{inst:5}} \and
-        David Berge \inst{\ref{inst:6}, \ref{inst:7}} \and
-        Pooja Bhattacharjee \inst{\ref{inst:8}} \and
-        Johannes Buchner \inst{\ref{inst:12}} \and
-        Catherine Boisson \inst{\ref{inst:9}} \and
-        David {Carreto Fidalgo} \inst{\ref{inst:13}} \and
-        Andrew Chen \inst{\ref{inst:14}} \and
-        Mathieu {de Bony de Lavergne} \inst{\ref{inst:8}} \and
-        José Vinícius {de Miranda Cardoso}\inst{\ref{inst:16}} \and
-        Christoph Deil \inst{\ref{inst:17}} \and
-        Matthias Fü{\ss}ling \inst{\ref{inst:18}} \and
-        Stefan Funk \inst{\ref{inst:19}} \and
-        Luca Giunti \inst{\ref{inst:20}} \and
-        Jim Hinton \inst{\ref{inst:17}} \and
-        Léa Jouvin \inst{\ref{inst:32}} \and
-        Johannes King \inst{\ref{inst:30}, \ref{inst:17}} \and
-        Julien Lefaucheur \inst{\ref{inst:21}, \ref{inst:20}} \and
-        Marianne Lemoine-Goumard \inst{\ref{inst:31}} \and
-        Jean-Philippe Lenain \inst{\ref{inst:22}} \and
-        Rub{\'e}n L{\'o}pez-Coto \inst{\ref{inst:23}} \and
-        Lars Mohrmann \inst{\ref{inst:17}} \and
-        Daniel Morcuende \inst{\ref{inst:15}} \and
-        Sebastian Panny \inst{\ref{inst:25}} \and
-        Maxime Regeard \inst{\ref{inst:20}} \and
-        Lab Saha \inst{\ref{inst:15}} \and
-        Hubert Siejkowski \inst{\ref{inst:27}} \and
-        Aneta Siemiginowska \inst{\ref{inst:28}} \and
-        Brigitta M. {Sipőcz} \inst{\ref{inst:29}} \and
-        Tim Unbehaun \inst{\ref{inst:19}} \and
-        Christopher {van Eldik} \inst{\ref{inst:19}} \and
-        Thomas Vuillaume \inst{\ref{inst:8}} \and
-        Roberta Zanin \inst{\ref{inst:18}}
+        \href{mailto:GAMMAPY-COORDINATION-L@IN2P3.FR}{GAMMAPY-COORDINATION-L@IN2P3.FR}} \inst{\ref{inst:001}} \and
+        Régis Terrier \inst{\ref{inst:002}} \and
+        Quentin Remy \inst{\ref{inst:003}} \and
+        Atreyee Sinha \inst{\ref{inst:004}} \and
+        Cosimo Nigro \inst{\ref{inst:005}} \and
+        Fabio Pintore \inst{\ref{inst:006}} \and
+        Bruno Khélifi \inst{\ref{inst:002}} \and
+        Laura Olivera-Nieto \inst{\ref{inst:003}}\and
+        Jose Enrique {Ruiz} \inst{\ref{inst:007}} \and
+        Kai Brügge \inst{\ref{inst:008},\ref{inst:009}} \and
+        Maximilian Linhoff \inst{\ref{inst:009}} \and
+        Jose Louis {Contreras} \inst{\ref{inst:004}} \and
+        Fabio Acero \inst{\ref{inst:010}} \and
+        Arnau Aguasca-Cabot \inst{\ref{inst:011}, \ref{inst:012}, \ref{inst:013}, \ref{inst:014}} \and
+        David Berge \inst{\ref{inst:015}, \ref{inst:016}} \and
+        Pooja Bhattacharjee \inst{\ref{inst:017}} \and
+        Johannes Buchner \inst{\ref{inst:018}} \and
+        Catherine Boisson \inst{\ref{inst:019}} \and
+        David {Carreto Fidalgo} \inst{\ref{inst:020}} \and
+        Andrew Chen \inst{\ref{inst:021}} \and
+        Mathieu {de Bony de Lavergne} \inst{\ref{inst:017}} \and
+        José Vinícius {de Miranda Cardoso}\inst{\ref{inst:022}} \and
+        Christoph Deil \inst{\ref{inst:003}} \and
+        Matthias Fü{\ss}ling \inst{\ref{inst:023}} \and
+        Stefan Funk \inst{\ref{inst:024}} \and
+        Luca Giunti \inst{\ref{inst:002}} \and
+        Jim Hinton \inst{\ref{inst:003}} \and
+        Léa Jouvin \inst{\ref{inst:025}} \and
+        Johannes King \inst{\ref{inst:026}, \ref{inst:003}} \and
+        Julien Lefaucheur \inst{\ref{inst:027}, \ref{inst:002}} \and
+        Marianne Lemoine-Goumard \inst{\ref{inst:028}} \and
+        Jean-Philippe Lenain \inst{\ref{inst:029}} \and
+        Rub{\'e}n L{\'o}pez-Coto \inst{\ref{inst:007}} \and
+        Lars Mohrmann \inst{\ref{inst:003}} \and
+        Daniel Morcuende \inst{\ref{inst:004}} \and
+        Sebastian Panny \inst{\ref{inst:032}} \and
+        Maxime Regeard \inst{\ref{inst:002}} \and
+        Lab Saha \inst{\ref{inst:004}} \and
+        Hubert Siejkowski \inst{\ref{inst:030}} \and
+        Aneta Siemiginowska \inst{\ref{inst:001}} \and
+        Brigitta M. {Sipőcz} \inst{\ref{inst:031}} \and
+        Tim Unbehaun \inst{\ref{inst:024}} \and
+        Christopher {van Eldik} \inst{\ref{inst:024}} \and
+        Thomas Vuillaume \inst{\ref{inst:017}} \and
+        Roberta Zanin \inst{\ref{inst:023}}
 }
 
 
@@ -136,38 +136,38 @@
 
 
 \institute{
-        Université Paris-Saclay, Université Paris Cité, CEA, CNRS, AIM, F-91191 Gif-sur-Yvette, France \label{inst:1} \and
-        Departament de Física Quàntica i Astrofísica (FQA), Universitat de Barcelona (UB),  c. Martí i Franqués, 1, 08028 Barcelona, Spain \label{inst:2} \and
-        Institut de Ciències del Cosmos (ICCUB), Universitat de Barcelona (UB), c. Martí i Franqués, 1, 08028 Barcelona, Spain \label{inst:3} \and
-        Institut d'Estudis Espacials de Catalunya (IEEC), c. Gran Capità, 2-4, 08034 Barcelona, Spain \label{inst:4} \and
-        Departament de Física Quàntica i Astrofísica, Institut de Ciències del Cosmos, Universitat de Barcelona, IEEC-UB, Martí i Franquès, 1, 08028, Barcelona, Spain \label{inst:5} \and
-        Deutsches Elektronen-Synchrotron (DESY), D-15738 Zeuthen, Germany \label{inst:6} \and
-        Institute of physics, Humboldt-University of Berlin, D-12489 Berlin, Germany \label{inst:7} \and
-        Université Savoie Mont Blanc, CNRS, Laboratoire d’Annecy de Physique des Particules - IN2P3, 74000 Annecy, France \label{inst:8} \and
-        Laboratoire Univers et Théories, Observatoire de Paris, Université PSL, Université Paris Cité, CNRS, F-92190 Meudon, France \label{inst:9} \and
-        Point8 GmbH \label{inst:10} \and
-        Astroparticle Physics, Department of Physics, TU Dortmund University, Otto-Hahn-Str. 4a, D-44227 Dortmund \label{inst:11} \and
-        Max Planck Institute for extraterrestrial Physics, Giessenbachstrasse, 85748 Garching, Germany \label{inst:12} \and
-        Max Planck Computing and Data Facility, Gießenbachstraße 2, 85748 Garching \label{inst:13} \and
-        School of Physics, University of the Witwatersrand, 1 Jan Smuts Avenue, Braamfontein, Johannesburg, 2050 South Africa \label{inst:14} \and
-        IPARCOS Institute and EMFTEL Department, Universidad Complutense de Madrid, E-28040 Madrid, Spain \label{inst:15} \and
-        The Hong Kong University of Science and Technology, Department of Electronic and Computer Engineering \label{inst:16} \and
-        Max-Planck-Institut für Kernphysik, P.O. Box 103980, D 69029 Heidelberg, Germany \label{inst:17} \and
-        Cherenkov Telescope Array Observatory gGmbH (CTAO gGmbH) Saupfercheckweg 1 69117 Heidelberg \label{inst:18} \and
-        Erlangen Centre for Astroparticle Physics (ECAP), Friedrich-Alexander-Universität Erlangen-Nürnberg, Nikolaus-Fiebiger Strasse 2, 91058 Erlangen, Germany \label{inst:19} \and
-        Université de Paris Cité, CNRS, Astroparticule et Cosmologie, F-75013 Paris, France  \label{inst:20} \and
-        Meteo France International \label{inst:21} \and
-        Sorbonne Université, Université Paris Diderot, Sorbonne Paris Cité, CNRS/IN2P3, Laboratoire de Physique Nucléaire et de Hautes Energies, LPNHE, 4 Place Jussieu, F-75252 Paris, France \label{inst:22} \and
-        Instituto de Astrofísica de Andalucía-CSIC, Glorieta de la Astronomía s/n, 18008, Granada, Spain \label{inst:23} \and
-        Institut de Física d'Altes Energies (IFAE), The Barcelona Institute of Science and Technology, Campus UAB, Bellaterra, 08193 Barcelona, Spain \label{inst:24} \and
-        Institut für Astro- und Teilchenphysik, Leopold-Franzens-Universität Innsbruck, A-6020 Innsbruck, Austria \label{inst:25} \and
-        INAF/IASF Palermo, Via U. La Malfa, 153, 90146 Palermo PA \label{inst:26} \and
-        Academic Computer Centre Cyfronet, AGH University of Science and Technology, Krakow, Poland \label{inst:27} \and
-        Center for Astrophysics | Harvard and Smithsonian \label{inst:28} \and
-        Caltech/IPAC, MC 100-22, 1200 E. California Boulevard, Pasadena, CA 91125 USA \label{inst:29} \and
-        Bruno-Bauer-Straße 22, 12051 Berlin  \label{inst:30} \and
-        Université Bordeaux, CNRS, LP2I Bordeaux, UMR 5797 \label{inst:31} \and
-        IRFU, CEA, Université Paris-Saclay, F-91191 Gif-sur-Yvette, France \label{inst:32}
+        Center for Astrophysics | Harvard and Smithsonian \label{inst:001} \and
+        Université de Paris Cité, CNRS, Astroparticule et Cosmologie, F-75013 Paris, France  \label{inst:002} \and
+        Max-Planck-Institut für Kernphysik, P.O. Box 103980, D 69029 Heidelberg, Germany \label{inst:003} \and
+        IPARCOS Institute and EMFTEL Department, Universidad Complutense de Madrid, E-28040 Madrid, Spain \label{inst:004} \and
+        Institut de Física d'Altes Energies (IFAE), The Barcelona Institute of Science and Technology, Campus UAB, Bellaterra, 08193 Barcelona, Spain \label{inst:005} \and
+        INAF/IASF Palermo, Via U. La Malfa, 153, 90146 Palermo PA \label{inst:006} \and
+        Instituto de Astrofísica de Andalucía-CSIC, Glorieta de la Astronomía s/n, 18008, Granada, Spain \label{inst:007} \and
+        Point8 GmbH \label{inst:008} \and
+        Astroparticle Physics, Department of Physics, TU Dortmund University, Otto-Hahn-Str. 4a, D-44227 Dortmund \label{inst:009} \and
+        Université Paris-Saclay, Université Paris Cité, CEA, CNRS, AIM, F-91191 Gif-sur-Yvette, France \label{inst:010} \and
+        Departament de Física Quàntica i Astrofísica (FQA), Universitat de Barcelona (UB),  c. Martí i Franqués, 1, 08028 Barcelona, Spain \label{inst:011} \and
+        Institut de Ciències del Cosmos (ICCUB), Universitat de Barcelona (UB), c. Martí i Franqués, 1, 08028 Barcelona, Spain \label{inst:012} \and
+        Institut d'Estudis Espacials de Catalunya (IEEC), c. Gran Capità, 2-4, 08034 Barcelona, Spain \label{inst:013} \and
+        Departament de Física Quàntica i Astrofísica, Institut de Ciències del Cosmos, Universitat de Barcelona, IEEC-UB, Martí i Franquès, 1, 08028, Barcelona, Spain \label{inst:014} \and
+        Deutsches Elektronen-Synchrotron (DESY), D-15738 Zeuthen, Germany \label{inst:015} \and
+        Institute of physics, Humboldt-University of Berlin, D-12489 Berlin, Germany \label{inst:016} \and
+        Université Savoie Mont Blanc, CNRS, Laboratoire d’Annecy de Physique des Particules - IN2P3, 74000 Annecy, France \label{inst:017} \and
+        Max Planck Institute for extraterrestrial Physics, Giessenbachstrasse, 85748 Garching, Germany \label{inst:018} \and
+        Laboratoire Univers et Théories, Observatoire de Paris, Université PSL, Université Paris Cité, CNRS, F-92190 Meudon, France \label{inst:019} \and
+        Max Planck Computing and Data Facility, Gießenbachstraße 2, 85748 Garching \label{inst:020} \and
+        School of Physics, University of the Witwatersrand, 1 Jan Smuts Avenue, Braamfontein, Johannesburg, 2050 South Africa \label{inst:021} \and
+        The Hong Kong University of Science and Technology, Department of Electronic and Computer Engineering \label{inst:022} \and
+        Cherenkov Telescope Array Observatory gGmbH (CTAO gGmbH) Saupfercheckweg 1 69117 Heidelberg \label{inst:023} \and
+        Erlangen Centre for Astroparticle Physics (ECAP), Friedrich-Alexander-Universität Erlangen-Nürnberg, Nikolaus-Fiebiger Strasse 2, 91058 Erlangen, Germany \label{inst:024} \and
+        IRFU, CEA, Université Paris-Saclay, F-91191 Gif-sur-Yvette, France \label{inst:025}
+        Bruno-Bauer-Straße 22, 12051 Berlin  \label{inst:026} \and
+        Meteo France International \label{inst:027} \and
+        Université Bordeaux, CNRS, LP2I Bordeaux, UMR 5797 \label{inst:028} \and
+        Sorbonne Université, Université Paris Diderot, Sorbonne Paris Cité, CNRS/IN2P3, Laboratoire de Physique Nucléaire et de Hautes Energies, LPNHE, 4 Place Jussieu, F-75252 Paris, France \label{inst:029} \and
+        Academic Computer Centre Cyfronet, AGH University of Science and Technology, Krakow, Poland \label{inst:030} \and
+        Caltech/IPAC, MC 100-22, 1200 E. California Boulevard, Pasadena, CA 91125 USA \label{inst:031} \and
+        Institut für Astro- und Teilchenphysik, Leopold-Franzens-Universität Innsbruck, A-6020 Innsbruck, Austria \label{inst:032}
 }
 
 

--- a/src/ms-review.tex
+++ b/src/ms-review.tex
@@ -1979,8 +1979,7 @@ a common vision of open and reproducible science for the future.
         invaluable to the development of \gammapy. We thank the \github team for
         providing us with an excellent free development platform. We also are grateful
         to Read the Docs (\ReadthedocsUrl), and Travis (\TravisUrl) for providing free
-        documentation hosting and testing respectively. A special acknowledgment has to be given
-        to our first Lead Developer of \gammapy, Christoph Deil. Finally, we would like to thank
+        documentation hosting and testing respectively. Finally, we would like to thank
         all the \gammapy users that have provided feedback and submitted bug reports.
 
         A.~Aguasca-Cabot acknowledges the financial support from the Spanish Ministry of Science and Innovation
@@ -2002,6 +2001,25 @@ a common vision of open and reproducible science for the future.
         Particle Physics ESFRI Research Infrastructures  funded by the European Union’s Horizon 2020 research and
         innovation program under Grant Agreement no. 824064 and from the Spanish Ministry of Universities through the
         Maria Zambrano Talent Attraction Programme, 2021-2023.
+
+        A special acknowledgment has to be given to our first lead developer, Christoph Deil, who
+        started the \gammapy project and set the foundation for its future success.
+
+        A. Donath, R. Terrier, Q. Remy, A. Sinha, C. Nigro, F. Pintore, B. Khélifi, L. Olivera-Nieto, J. E. Ruiz,
+        K. Brügge, M. Linhoff and J.L. Contreras contributed to the writing of the manuscript.
+        
+        A. Donath, B. Khélifi, C. Boisson, C.Deil, C. van Eldik, D. Berge, E. de Ona Wilhelmi, F. Acero, F. Pintore,
+        M. Cardillo, J. Hinton, J.L. Contreras, M. Fuessling, R. Terrier, R. Zanin, R. López-Coto and S. Funk
+        are current or former members of the Gammapy coordination committee and contributed to promotion, coordination
+        and steering of the \gammapy project.
+
+        A. Aguasca-Cabot, P. Bhattacharjee, K. Brügge, J. Buchner, D. Carreto Fidalgo, A. Chen, M. de Bony de Lavergne,
+        A. Donath, J. V. de Miranda Cardoso, C. Deil, L. Giunti, L. Jouvin, B. Khélifi, J. King, J. Lefaucheur,
+        M. Lemoine-Goumard, J.P. Lenain, M. Linhoff, L. Mohrmann, D. Morcuende, C. Nigro, L. Olivera-Nieto,
+        S. Panny, M. Regeard, Q. Remy, J. E. Ruiz, L. Saha, H. Siejkowski, A. Siemiginowska, A. Sinha,
+        B. M. Sipőcz, R. Terrier, T. Unbehaun, T. Vuillaume contributed to the code development of \gammapy.
+
+
 
 \end{acknowledgements}
 

--- a/src/ms-review.tex
+++ b/src/ms-review.tex
@@ -83,8 +83,8 @@
 \authorrunning{The Gammapy project}
 
 \author{
-        {\it Paper Authors} \and
-    Axel Donath \inst{\ref{inst:28}} \and
+        Axel Donath \thanks{Mail inquiries to:
+        \href{mailto:GAMMAPY-COORDINATION-L@IN2P3.FR}{GAMMAPY-COORDINATION-L@IN2P3.FR}} \inst{\ref{inst:28}} \and
         Régis Terrier \inst{\ref{inst:20}} \and
         Quentin Remy \inst{\ref{inst:17}} \and
         Atreyee Sinha \inst{\ref{inst:15}} \and
@@ -96,39 +96,27 @@
         Kai Brügge \inst{\ref{inst:10},\ref{inst:11}} \and
         Maximilian Linhoff \inst{\ref{inst:11}} \and
         Jose Louis {Contreras} \inst{\ref{inst:15}} \and
-        \\
-        {\it Coordination Committee}\thanks{Corresponding author:
-\href{mailto:GAMMAPY-COORDINATION-L@IN2P3.FR}{GAMMAPY-COORDINATION-L@IN2P3.FR}} \and
         Fabio Acero \inst{\ref{inst:1}} \and
-        David Berge \inst{\ref{inst:6}, \ref{inst:7}} \and
-        Catherine Boisson \inst{\ref{inst:9}} \and
-        Jose Louis {Contreras} \inst{\ref{inst:15}} \and
-        Axel Donath \inst{\ref{inst:28}} \and
-        Stefan Funk \inst{\ref{inst:19}} \and
-        Christopher {van Eldik} \inst{\ref{inst:19}} \and
-        Matthias Fü{\ss}ling \inst{\ref{inst:18}} \and
-        Jim Hinton \inst{\ref{inst:17}} \and
-        Bruno Khélifi \inst{\ref{inst:20}} \and
-        Rub{\'e}n L{\'o}pez-Coto \inst{\ref{inst:23}} \and
-        Fabio Pintore \inst{\ref{inst:26}} \and
-        Régis Terrier \inst{\ref{inst:20}} \and
-        Roberta Zanin \inst{\ref{inst:18}} \and
-    \\
-        {\it Gammapy Project Contributors} \and
         Arnau Aguasca-Cabot \inst{\ref{inst:2}, \ref{inst:3}, \ref{inst:4}, \ref{inst:5}} \and
+        David Berge \inst{\ref{inst:6}, \ref{inst:7}} \and
         Pooja Bhattacharjee \inst{\ref{inst:8}} \and
         Johannes Buchner \inst{\ref{inst:12}} \and
+        Catherine Boisson \inst{\ref{inst:9}} \and
         David {Carreto Fidalgo} \inst{\ref{inst:13}} \and
         Andrew Chen \inst{\ref{inst:14}} \and
         Mathieu {de Bony de Lavergne} \inst{\ref{inst:8}} \and
         José Vinícius {de Miranda Cardoso}\inst{\ref{inst:16}} \and
         Christoph Deil \inst{\ref{inst:17}} \and
+        Matthias Fü{\ss}ling \inst{\ref{inst:18}} \and
+        Stefan Funk \inst{\ref{inst:19}} \and
         Luca Giunti \inst{\ref{inst:20}} \and
+        Jim Hinton \inst{\ref{inst:17}} \and
         Léa Jouvin \inst{\ref{inst:32}} \and
         Johannes King \inst{\ref{inst:30}, \ref{inst:17}} \and
         Julien Lefaucheur \inst{\ref{inst:21}, \ref{inst:20}} \and
         Marianne Lemoine-Goumard \inst{\ref{inst:31}} \and
         Jean-Philippe Lenain \inst{\ref{inst:22}} \and
+        Rub{\'e}n L{\'o}pez-Coto \inst{\ref{inst:23}} \and
         Lars Mohrmann \inst{\ref{inst:17}} \and
         Daniel Morcuende \inst{\ref{inst:15}} \and
         Sebastian Panny \inst{\ref{inst:25}} \and
@@ -138,8 +126,12 @@
         Aneta Siemiginowska \inst{\ref{inst:28}} \and
         Brigitta M. {Sipőcz} \inst{\ref{inst:29}} \and
         Tim Unbehaun \inst{\ref{inst:19}} \and
-        Thomas Vuillaume \inst{\ref{inst:8}}
+        Christopher {van Eldik} \inst{\ref{inst:19}} \and
+        Thomas Vuillaume \inst{\ref{inst:8}} \and
+        Roberta Zanin \inst{\ref{inst:18}}
 }
+
+
 
 
 

--- a/src/ms-review.tex
+++ b/src/ms-review.tex
@@ -1979,7 +1979,7 @@ a common vision of open and reproducible science for the future.
         invaluable to the development of \gammapy. We thank the \github team for
         providing us with an excellent free development platform. We also are grateful
         to Read the Docs (\ReadthedocsUrl), and Travis (\TravisUrl) for providing free
-        documentation hosting and testing respectively. Finally, we would like to thank
+        documentation hosting and testing respectively. We would like to thank
         all the \gammapy users that have provided feedback and submitted bug reports.
 
         A.~Aguasca-Cabot acknowledges the financial support from the Spanish Ministry of Science and Innovation
@@ -2005,21 +2005,20 @@ a common vision of open and reproducible science for the future.
         A special acknowledgment has to be given to our first lead developer, Christoph Deil, who
         started the \gammapy project and set the foundation for its future success.
 
-        A. Donath, R. Terrier, Q. Remy, A. Sinha, C. Nigro, F. Pintore, B. Khélifi, L. Olivera-Nieto, J. E. Ruiz,
-        K. Brügge, M. Linhoff and J.L. Contreras contributed to the writing of the manuscript.
+        For contributing to the writing of the manuscript, we thank A. Donath, R. Terrier, Q. Remy, A. Sinha,
+        C. Nigro, F. Pintore, B. Khélifi, L. Olivera-Nieto, J. E. Ruiz, K. Brügge, M. Linhoff and J.L. Contreras.
         
-        A. Donath, B. Khélifi, C. Boisson, C.Deil, C. van Eldik, D. Berge, E. de Ona Wilhelmi, F. Acero, F. Pintore,
-        M. Cardillo, J. Hinton, J.L. Contreras, M. Fuessling, R. Terrier, R. Zanin, R. López-Coto and S. Funk
-        are current or former members of the Gammapy coordination committee and contributed to promotion, coordination
-        and steering of the \gammapy project.
+        We also thank the current and former members of the Gammapy coordination committee A. Donath, B. Khélifi,
+        C. Boisson, C.Deil, C. van Eldik, D. Berge, E. de Ona Wilhelmi, F. Acero, F. Pintore,
+        M. Cardillo, J. Hinton, J.L. Contreras, M. Fuessling, R. Terrier, R. Zanin, R. López-Coto and S. Funk,
+        who contributed to promotion, coordination and steering of the \gammapy project.
 
-        A. Aguasca-Cabot, P. Bhattacharjee, K. Brügge, J. Buchner, D. Carreto Fidalgo, A. Chen, M. de Bony de Lavergne,
-        A. Donath, J. V. de Miranda Cardoso, C. Deil, L. Giunti, L. Jouvin, B. Khélifi, J. King, J. Lefaucheur,
-        M. Lemoine-Goumard, J.P. Lenain, M. Linhoff, L. Mohrmann, D. Morcuende, C. Nigro, L. Olivera-Nieto,
-        S. Panny, M. Regeard, Q. Remy, J. E. Ruiz, L. Saha, H. Siejkowski, A. Siemiginowska, A. Sinha,
-        B. M. Sipőcz, R. Terrier, T. Unbehaun, T. Vuillaume contributed to the code development of \gammapy.
-
-
+        Finally we would like to thank A. Aguasca-Cabot, P. Bhattacharjee, K. Brügge, J. Buchner, D. Carreto
+        Fidalgo, A. Chen, M. de Bony de Lavergne, A. Donath, J. V. de Miranda Cardoso, C. Deil, L. Giunti,
+        L. Jouvin, B. Khélifi, J. King, J. Lefaucheur, M. Lemoine-Goumard, J.P. Lenain, M. Linhoff,
+        L. Mohrmann, D. Morcuende, C. Nigro, L. Olivera-Nieto, S. Panny, F. Pintore, M. Regeard,
+        Q. Remy, J. E. Ruiz, L. Saha, H. Siejkowski, A. Siemiginowska, A. Sinha, B. M. Sipőcz, R. Terrier,
+        T. Unbehaun, T. Vuillaume and unnamed contributors for contributing to the development of \gammapy.
 
 \end{acknowledgements}
 


### PR DESCRIPTION
This PR reformats the author list following a request by the A&A's publication office. It includes the following changes:

- Remove the split author list
- Merge the contributors and CC member into a single author list
- Add a short declaration of contributions to the acknowledgment section

The preview of the pdf is [here](https://github.com/adonath/gammapy-v1.0-paper/blob/reformat_author_list-pdf/ms.pdf)

CC @bkhelifi @Bultako @kbruegge @registerrier @maxnoe @LauraOlivera @AtreyeeS @contrera @QRemy @cosimoNigro @fabiopintore 